### PR TITLE
good news: delete_ss() now takes a regular expression [covr]

### DIFF
--- a/man/delete_ss.Rd
+++ b/man/delete_ss.Rd
@@ -2,30 +2,29 @@
 % Please edit documentation in R/edit-spreadsheets.R
 \name{delete_ss}
 \alias{delete_ss}
-\title{Move a spreadsheet to trash on Google Drive}
+\title{Move spreadsheets to trash on Google Drive}
 \usage{
-delete_ss(x, verbose = TRUE)
+delete_ss(x, verbose = TRUE, ...)
 }
 \arguments{
-\item{x}{sheet-identifying information, either a gspreadsheet object or a
-character vector of length one, giving a URL, sheet title, key or
-worksheets feed}
+\item{x}{a regular expression; spreadsheets whose titles match will be moved
+to trash}
 
 \item{verbose}{logical; do you want informative message?}
+
+\item{...}{optional arguments to be passed to \code{\link{grepl}}}
 }
 \value{
-logical, TRUE if deletion has been explicitly confirmed, FALSE
-  otherwise
+tbl_df with one row per matching sheet, a variable holding
+  spreadsheet titles, a logical vector indicating deletion success
 }
 \description{
-You must own the sheet in order to move it to the trash. If you try to delete
-a sheet you do not own, a 403 Forbidden HTTP status code will be returned;
-such shared spreadsheets can only be moved to the trash manually in the web
+You must own a sheet in order to move it to the trash. If you try to delete a
+sheet you do not own, a 403 Forbidden HTTP status code will be returned; such
+shared spreadsheets can only be moved to the trash manually in the web
 browser. If you trash a spreadsheet that is shared with others, it will no
-longer appear in any of their Google Drives.
-}
-\note{
-Use the key when there are multiple sheets with the same name, since
-  the default will just send the most recent sheet to the trash.
+longer appear in any of their Google Drives. If you delete something my
+mistake, visit the \href{https://drive.google.com/drive/#trash}{trash in
+Google Drive}, find the sheet and restore it.
 }
 

--- a/tests/testthat/test-edit-spreadsheets.R
+++ b/tests/testthat/test-edit-spreadsheets.R
@@ -10,9 +10,29 @@ test_that("Spreadsheet can be created and deleted", {
   ss_df <- list_sheets()
   expect_true(sheet_title %in% ss_df$sheet_title)
   expect_message(tmp <- delete_ss(sheet_title), "moved to trash")
-  expect_true(tmp)
   ss_df <- list_sheets()
   expect_false(sheet_title %in% ss_df$sheet_title)
+  
+})
+
+test_that("Regexes work for deleting multiple sheets", {
+  
+  sheet_title <- c("cat", "catherine", "tomCAT", "abdicate", "FLYCATCHER")
+  sapply(sheet_title, new_ss)
+  
+  delete_ss("^cat$")
+  ss_df <- list_sheets()
+  expect_false("cat" %in% ss_df$sheet_title)
+  expect_true(all(sheet_title[-1] %in% ss_df$sheet_title))
+  
+  delete_ss("cat")
+  ss_df <- list_sheets()
+  expect_false(any(c("catherine", "abdicate") %in% ss_df$sheet_title))
+  expect_true(all(c("tomCAT", "FLYCATCHER") %in% ss_df$sheet_title))
+  
+  delete_ss("cat", ignore.case = TRUE)
+  ss_df <- list_sheets()
+  expect_false(any(sheet_title %in% ss_df$sheet_title))
   
 })
 
@@ -36,7 +56,7 @@ test_that("Spreadsheet can be copied", {
 
 test_that("Nonexistent spreadsheet can NOT be deleted or copied", {
   
-  expect_error(delete_ss("flyingpig"), "doesn't match")
+  expect_message(delete_ss("flyingpig"), "No matching")
   expect_error(copy_ss("flyingpig"),  "doesn't match")
   
 })
@@ -139,6 +159,5 @@ my_patterns <- c("testing[0-9]{1}", "gap-data",
                  paste("Copy of", pts_title),
                  "eggplants are purple")
 my_patterns <- my_patterns %>% stringr::str_c(collapse = "|")
-sheets_to_delete <- list_sheets() %>%
-  dplyr::filter(stringr::str_detect(sheet_title, my_patterns))
-sapply(sheets_to_delete$sheet_key, delete_ss, verbose = FALSE)
+delete_ss(my_patterns, verbose = FALSE)
+

--- a/vignettes/basic-usage.R
+++ b/vignettes/basic-usage.R
@@ -23,9 +23,7 @@ if(length(HTTR_OAUTH) > 0) {
 ## aborts, clean up Google Drive first
 my_patterns <- c("hi I am new here")
 my_patterns <- my_patterns %>% stringr::str_c(collapse = "|")
-sheets_to_delete <- list_sheets() %>%
-  dplyr::filter(stringr::str_detect(sheet_title, my_patterns))
-sapply(sheets_to_delete$sheet_key, delete_ss, verbose = FALSE)
+delete_ss(my_patterns, verbose = FALSE)
 
 ## ----copy-gapminder, eval = FALSE----------------------------------------
 #  gap_key <- "1hS762lIJd2TRUTVOqoOP7g-h4MDQs6b2vhkTzohg8bE"

--- a/vignettes/basic-usage.Rmd
+++ b/vignettes/basic-usage.Rmd
@@ -53,9 +53,7 @@ if(length(HTTR_OAUTH) > 0) {
 ## aborts, clean up Google Drive first
 my_patterns <- c("hi I am new here")
 my_patterns <- my_patterns %>% stringr::str_c(collapse = "|")
-sheets_to_delete <- list_sheets() %>%
-  dplyr::filter(stringr::str_detect(sheet_title, my_patterns))
-sapply(sheets_to_delete$sheet_key, delete_ss, verbose = FALSE)
+delete_ss(my_patterns, verbose = FALSE)
 ```
 
 

--- a/vignettes/basic-usage.html
+++ b/vignettes/basic-usage.html
@@ -104,12 +104,12 @@ code > span.er { color: #ff0000; font-weight: bold; }
 <pre><code>## Source: local data frame [6 x 5]
 ## 
 ##   sheet_title  sheet_key    owner perm        last_updated
-## 1  Public Tes 1hff6Az... gspreadr   rw 2015-03-22 22:31:20
-## 2     scoring 1w8F3t9... gspreadr   rw 2015-03-20 22:32:48
-## 3  gas_mileag 1WH65aJ... woo.kara    r 2015-03-12 01:01:33
-## 4  Temperatur 1Hkh20-... gspreadr   rw 2015-03-03 00:07:43
-## 5  1F0iNuYW4v 1upHM4K... gspreadr   rw 2015-02-20 01:17:28
-## 6  Testing he 1F0iNuY... gspreadr   rw 2015-02-20 01:14:15</code></pre>
+## 1  Public Tes 1hff6Az... gspreadr   rw 2015-03-23 04:27:03
+## 2  Testing he 1F0iNuY... gspreadr   rw 2015-03-23 03:30:29
+## 3     scoring 1w8F3t9... gspreadr   rw 2015-03-20 22:32:48
+## 4  gas_mileag 1WH65aJ... woo.kara    r 2015-03-12 01:01:33
+## 5  Temperatur 1Hkh20-... gspreadr   rw 2015-03-03 00:07:43
+## 6  1F0iNuYW4v 1upHM4K... gspreadr   rw 2015-02-20 01:17:28</code></pre>
 <p>This provides a nice overview of the spreadsheets you can access and is useful for looking up the <strong>key</strong> of a spreadsheet (see below).</p>
 </div>
 <div id="register-a-spreadsheet" class="section level1">
@@ -122,7 +122,7 @@ code > span.er { color: #ff0000; font-weight: bold; }
 ## sheet_key: 1hS762lIJd2TRUTVOqoOP7g-h4MDQs6b2vhkTzohg8bE</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(gap)</code></pre>
 <pre><code>##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:32 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -149,7 +149,7 @@ code > span.er { color: #ff0000; font-weight: bold; }
 ## sheet_key: 1hS762lIJd2TRUTVOqoOP7g-h4MDQs6b2vhkTzohg8bE</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(ss2)</code></pre>
 <pre><code>##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:33 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -173,7 +173,7 @@ code > span.er { color: #ff0000; font-weight: bold; }
 <p>Example of getting nice tabular data from the “list feed”:</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(gap)</code></pre>
 <pre><code>##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:32 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -302,16 +302,18 @@ code > span.er { color: #ff0000; font-weight: bold; }
 ## Identifying info is a gspreadsheet object; gspreadr will re-identify the sheet based on sheet key.
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 12yp3IhuC2IRSC3g0s9WNUyIh6hyP3GMuGaG4BmeBylU</code></pre>
+## sheet_key: 1E7BsG2qYdt1nY_W1oYkTan0wMsQquECKYCNSDr--bfc</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">list_sheets</span>() %&gt;%<span class="st"> </span><span class="kw">filter</span>(sheet_title ==<span class="st"> &quot;hi I am new here&quot;</span>)</code></pre>
 <pre><code>## Source: local data frame [1 x 6]
 ## 
 ##        sheet_title                                    sheet_key    owner
-## 1 hi I am new here 12yp3IhuC2IRSC3g0s9WNUyIh6hyP3GMuGaG4BmeBylU gspreadr
+## 1 hi I am new here 1E7BsG2qYdt1nY_W1oYkTan0wMsQquECKYCNSDr--bfc gspreadr
 ## Variables not shown: perm (chr), last_updated (time), ws_feed (chr)</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># Move spreadsheet to trash</span>
 <span class="kw">delete_ss</span>(<span class="st">&quot;hi I am new here&quot;</span>)</code></pre>
-<pre><code>## Sheet &quot;hi I am new here&quot; moved to trash in Google Drive.</code></pre>
+<pre><code>## Sheets found and slated for deletion:
+## hi I am new here
+## Success. All moved to trash in Google Drive.</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">list_sheets</span>() %&gt;%<span class="st"> </span><span class="kw">filter</span>(sheet_title ==<span class="st"> &quot;hi I am new here&quot;</span>)</code></pre>
 <pre><code>## Source: local data frame [0 x 6]
 ## 
@@ -326,56 +328,58 @@ code > span.er { color: #ff0000; font-weight: bold; }
 ## Identifying info is a gspreadsheet object; gspreadr will re-identify the sheet based on sheet key.
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r">x &lt;-<span class="st"> </span><span class="kw">register_ss</span>(<span class="st">&quot;hi I am new here&quot;</span>)</code></pre>
 <pre><code>## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(x)</code></pre>
 <pre><code>##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:27 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:25 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:43 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:41 UTC
 ## 
 ## Contains 1 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r">x &lt;-<span class="st"> </span><span class="kw">add_ws</span>(x, <span class="dt">ws_title =</span> <span class="st">&quot;foo&quot;</span>, <span class="dt">nrow =</span> <span class="dv">10</span>, <span class="dt">ncol =</span> <span class="dv">10</span>)</code></pre>
 <pre><code>## Worksheet &quot;foo&quot; added to sheet &quot;hi I am new here&quot;.</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(x)</code></pre>
 <pre><code>##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:28 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:28 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:44 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:44 UTC
 ## 
 ## Contains 2 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## foo: 10 x 10
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">delete_ws</span>(x, <span class="dt">ws_title =</span> <span class="st">&quot;foo&quot;</span>)</code></pre>
 <pre><code>## Worksheet &quot;foo&quot; deleted from sheet &quot;hi I am new here&quot;.</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r">x &lt;-<span class="st"> </span><span class="kw">register_ss</span>(<span class="st">&quot;hi I am new here&quot;</span>)</code></pre>
 <pre><code>## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">str</span>(x)</code></pre>
 <pre><code>##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:30 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:29 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:32:44 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:46 UTC
 ## 
 ## Contains 1 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA</code></pre>
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k</code></pre>
 <p>To rename a worksheet, pass in the spreadsheet object, the worksheet’s current name and the new name you want it to be.</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">rename_ws</span>(x, <span class="st">&quot;Sheet1&quot;</span>, <span class="st">&quot;First Sheet&quot;</span>)</code></pre>
 <pre><code>## Worksheet &quot;Sheet1&quot; renamed to &quot;First Sheet&quot;.</code></pre>
 <p>Tidy up by getting rid of the sheet we’ve playing with.</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">delete_ss</span>(<span class="st">&quot;hi I am new here&quot;</span>)</code></pre>
-<pre><code>## Sheet &quot;hi I am new here&quot; moved to trash in Google Drive.</code></pre>
+<pre><code>## Sheets found and slated for deletion:
+## hi I am new here
+## Success. All moved to trash in Google Drive.</code></pre>
 </div>
 </div>
 <div id="worksheet-operations" class="section level1">

--- a/vignettes/basic-usage.md
+++ b/vignettes/basic-usage.md
@@ -53,12 +53,12 @@ Explore the `my_sheets` object. Here's a look at the top of ours, where we've tr
 ## Source: local data frame [6 x 5]
 ## 
 ##   sheet_title  sheet_key    owner perm        last_updated
-## 1  Public Tes 1hff6Az... gspreadr   rw 2015-03-22 22:31:20
-## 2     scoring 1w8F3t9... gspreadr   rw 2015-03-20 22:32:48
-## 3  gas_mileag 1WH65aJ... woo.kara    r 2015-03-12 01:01:33
-## 4  Temperatur 1Hkh20-... gspreadr   rw 2015-03-03 00:07:43
-## 5  1F0iNuYW4v 1upHM4K... gspreadr   rw 2015-02-20 01:17:28
-## 6  Testing he 1F0iNuY... gspreadr   rw 2015-02-20 01:14:15
+## 1  Public Tes 1hff6Az... gspreadr   rw 2015-03-23 04:27:03
+## 2  Testing he 1F0iNuY... gspreadr   rw 2015-03-23 03:30:29
+## 3     scoring 1w8F3t9... gspreadr   rw 2015-03-20 22:32:48
+## 4  gas_mileag 1WH65aJ... woo.kara    r 2015-03-12 01:01:33
+## 5  Temperatur 1Hkh20-... gspreadr   rw 2015-03-03 00:07:43
+## 6  1F0iNuYW4v 1upHM4K... gspreadr   rw 2015-02-20 01:17:28
 ```
 
 This provides a nice overview of the spreadsheets you can access and is useful for looking up the __key__ of a spreadsheet (see below).
@@ -86,7 +86,7 @@ str(gap)
 
 ```
 ##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:32 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -133,7 +133,7 @@ str(ss2)
 
 ```
 ##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:33 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -165,7 +165,7 @@ str(gap)
 
 ```
 ##               Spreadsheet title: Gapminder
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:17 PDT
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:32 PDT
 ## Date of last spreadsheet update: 2015-01-21 18:42:42 UTC
 ## 
 ## Contains 5 worksheets:
@@ -358,7 +358,7 @@ new_ss("hi I am new here")
 ## Identifying info is a gspreadsheet object; gspreadr will re-identify the sheet based on sheet key.
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 12yp3IhuC2IRSC3g0s9WNUyIh6hyP3GMuGaG4BmeBylU
+## sheet_key: 1E7BsG2qYdt1nY_W1oYkTan0wMsQquECKYCNSDr--bfc
 ```
 
 ```r
@@ -369,7 +369,7 @@ list_sheets() %>% filter(sheet_title == "hi I am new here")
 ## Source: local data frame [1 x 6]
 ## 
 ##        sheet_title                                    sheet_key    owner
-## 1 hi I am new here 12yp3IhuC2IRSC3g0s9WNUyIh6hyP3GMuGaG4BmeBylU gspreadr
+## 1 hi I am new here 1E7BsG2qYdt1nY_W1oYkTan0wMsQquECKYCNSDr--bfc gspreadr
 ## Variables not shown: perm (chr), last_updated (time), ws_feed (chr)
 ```
 
@@ -379,7 +379,9 @@ delete_ss("hi I am new here")
 ```
 
 ```
-## Sheet "hi I am new here" moved to trash in Google Drive.
+## Sheets found and slated for deletion:
+## hi I am new here
+## Success. All moved to trash in Google Drive.
 ```
 
 ```r
@@ -407,7 +409,7 @@ new_ss("hi I am new here")
 ## Identifying info is a gspreadsheet object; gspreadr will re-identify the sheet based on sheet key.
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 ```r
@@ -417,7 +419,7 @@ x <- register_ss("hi I am new here")
 ```
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 ```r
@@ -426,14 +428,14 @@ str(x)
 
 ```
 ##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:27 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:25 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:43 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:41 UTC
 ## 
 ## Contains 1 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 ```r
@@ -450,15 +452,15 @@ str(x)
 
 ```
 ##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:28 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:28 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:30:44 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:44 UTC
 ## 
 ## Contains 2 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## foo: 10 x 10
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 ```r
@@ -476,7 +478,7 @@ x <- register_ss("hi I am new here")
 ```
 ## Sheet identified!
 ## sheet_title: hi I am new here
-## sheet_key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## sheet_key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 ```r
@@ -485,14 +487,14 @@ str(x)
 
 ```
 ##               Spreadsheet title: hi I am new here
-##   Date of gspreadr::register_ss: 2015-03-22 15:32:30 PDT
-## Date of last spreadsheet update: 2015-03-22 22:32:29 UTC
+##   Date of gspreadr::register_ss: 2015-03-22 21:32:44 PDT
+## Date of last spreadsheet update: 2015-03-23 04:30:46 UTC
 ## 
 ## Contains 1 worksheets:
 ## (Title): (Nominal worksheet extent as rows x columns)
 ## Sheet1: 1000 x 26
 ## 
-## Key: 1ZOFza-OY2nyWPS8bdr_r4ZQx271f_g0mu5a59EvMbRA
+## Key: 1V_Neb6-JAoENyND8NKPwwJJZU9SbHPeSTVtRtgFZ29k
 ```
 
 To rename a worksheet, pass in the spreadsheet object, the worksheet's current name and the new name you want it to be.  
@@ -514,7 +516,9 @@ delete_ss("hi I am new here")
 ```
 
 ```
-## Sheet "hi I am new here" moved to trash in Google Drive.
+## Sheets found and slated for deletion:
+## hi I am new here
+## Success. All moved to trash in Google Drive.
 ```
 
 # Worksheet Operations


### PR DESCRIPTION
bad news: currently identifies sheets to delete based on matching the regex in the titles; can't directly delete based on, e.g., key or gspreadsheet object right now